### PR TITLE
Return only files from _get_file_sources

### DIFF
--- a/infobserve/processors/yara_processor.py
+++ b/infobserve/processors/yara_processor.py
@@ -223,7 +223,8 @@ class YaraProcessor:
                 yield filepath.as_posix()
             else:
                 for inner_file in Path().glob(rule_file):
-                    yield inner_file.as_posix()
+                    if inner_file.is_file():
+                        yield inner_file.as_posix()
 
     @staticmethod
     def _has_blacklist(matches):


### PR DESCRIPTION
YaraProcessor._get_file_sources checked whether the
current hit was a file, in which case it was returned. If it was
a directory, it returned all hits within that. This was a bug since
the inner hit could have been a directory itself.
This commit checks that the inner hit is indeed a file before yielding
it

Closes: #1